### PR TITLE
Fix sudo permissions issue in deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,25 +24,18 @@ jobs:
 
       - name: Deploy to server
         run: |
-          # Create deployment directory structure
-          ssh ${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }} "sudo mkdir -p /var/www/html/css /var/www/html/images"
-          
-          # Copy HTML files
-          scp *.html ${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }}:/tmp/
-          ssh ${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }} "sudo mv /tmp/*.html /var/www/html/"
+          # Copy HTML files directly
+          scp *.html ${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }}:/var/www/html/
           
           # Copy CSS files
-          scp css/*.css ${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }}:/tmp/
-          ssh ${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }} "sudo mv /tmp/*.css /var/www/html/css/"
+          ssh ${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }} "mkdir -p /var/www/html/css"
+          scp css/*.css ${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }}:/var/www/html/css/
           
           # Copy images
-          scp images/* ${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }}:/tmp/
-          ssh ${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }} "sudo mv /tmp/me.jpg /var/www/html/images/ 2>/dev/null || true"
+          ssh ${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }} "mkdir -p /var/www/html/images"
+          scp images/* ${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }}:/var/www/html/images/
           
-          # Set proper permissions
-          ssh ${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }} "sudo chown -R www-data:www-data /var/www/html && sudo chmod -R 644 /var/www/html && sudo find /var/www/html -type d -exec chmod 755 {} \;"
-          
-          # Reload nginx
+          # Reload nginx (assuming mikko user has sudo rights for this specific command)
           ssh ${{ secrets.SSH_USERNAME }}@${{ secrets.SSH_HOST }} "sudo systemctl reload nginx"
 
       - name: Cleanup SSH key


### PR DESCRIPTION
- Remove sudo requirements for file operations
- Copy files directly to /var/www/html/ directories
- Keep sudo only for nginx reload command
- Requires passwordless sudo configuration for systemctl reload nginx

🤖 Generated with [Claude Code](https://claude.ai/code)