### PR TITLE
Update job title to include Test Automation Engineer

### DIFF
--- a/cv_en.html
+++ b/cv_en.html
@@ -36,7 +36,7 @@
 				<a href="./index.html">Suomeksi</a>
 			<h3>Experience</h3>
 
-			<h5>8.2019 - Mitsubishi Logisnext Europe, Järvenpää, Product Owner <span title="Edited with help of Claude.ai">🤖</span></h5>
+			<h5>8.2019 - Mitsubishi Logisnext Europe, Järvenpää, Test Automation Engineer / Product Owner <span title="Edited with help of Claude.ai">🤖</span></h5>
 			<p>
 				<i><a href="https://rocla-agv.com/">Rocla AGV</a> manufactures Automated Guided Vehicles (AGVs) and develops 
 				FleetController software for fleet management.</i>

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
 						<a href="./cv_en.html">in English</a>
 					
 					<h3>Työkokemus</h3>
-					<h5>8.2019 - Mitsubishi Logisnext Europe, Järvenpää, Product Owner <span title="Edited with help of Claude.ai">🤖</span></h5>
+					<h5>8.2019 - Mitsubishi Logisnext Europe, Järvenpää, Test Automation Engineer / Product Owner <span title="Edited with help of Claude.ai">🤖</span></h5>
 					<p>
 						<i><a href="https://rocla-agv.com/">Rocla AGV</a> valmistaa automaattisia ohjattuja ajoneuvoja (AGV) ja kehittää 
 						FleetController-ohjelmistoa kalustohallintaan.</i>


### PR DESCRIPTION
- Add 'Test Automation Engineer / Product Owner' to both CV pages
- Better reflects dual role responsibilities at Mitsubishi Logisnext Europe
- Emphasizes test automation expertise alongside product ownership

🤖 Generated with [Claude Code](https://claude.ai/code)